### PR TITLE
Add unit vector scaled constraint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HMCUtilities"
 uuid = "2ce65f13-0017-5457-951f-edae629efa5e"
 authors = ["Seth Axen <seth.axen@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"


### PR DESCRIPTION
This is similar to the `UnitVectorConstraint` and likewise produces unit vectors, but the latent space is scaled by a radius `r`. This can be used to improve the initial scaling of the latent space for HMC, for example to bring rigid bodies rotations to a similar scale as their rotations in the latent space.

cc @ichem001 